### PR TITLE
Bribes redirection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ __pycache__
 build/
 reports/
 .env
+venv/
 
 node_modules/

--- a/contracts/MyStrategy.sol
+++ b/contracts/MyStrategy.sol
@@ -26,7 +26,7 @@ import {IWeth} from "../interfaces/weth/IWeth.sol";
  * - Removes hardcoded redirection path for BADGER to the BadgerTree
  * - Introduces bribes redirection paths for certain bribe tokens
  * - Introduces the bribe redirection fee and processing
- * - Setter function for the above
+ * - Introduces a setter function for the above
  */
 
 contract MyStrategy is BaseStrategy, ReentrancyGuardUpgradeable {
@@ -141,7 +141,7 @@ contract MyStrategy is BaseStrategy, ReentrancyGuardUpgradeable {
     }
 
      /// @dev Sets the redirection path for a given token as well as the redirection fee to 
-     ///     processed for this recepient.
+     ///      process for this recepient.
      /// @notice There can only be one recepient per token, calling this function for the same
      /// @notice token will replace the previous one.
      /// @notice Adding a token to this mapping means that the full amount (minus the fee) of this
@@ -497,7 +497,7 @@ contract MyStrategy is BaseStrategy, ReentrancyGuardUpgradeable {
         emit RewardsCollected(token, amount);
     }
 
-    /// @dev Takes a fee on the token and sends remaining to the given briber destination
+    /// @dev Takes a fee on the token and sends remaining to the given briber recepient
     function _sendTokenToBriber(address token, address recepient, uint256 amount) internal {
         // Process redirection fee
         uint256 redirectionFee = amount.mul(redirectionFees[recepient]).div(MAX_BPS);

--- a/contracts/MyStrategy.sol
+++ b/contracts/MyStrategy.sol
@@ -137,7 +137,7 @@ contract MyStrategy is BaseStrategy, ReentrancyGuardUpgradeable {
      /// @notice Adding a token to this mapping means that the full amount (minus the fee) of this
      /// @notice token, claimed from HiddenHands, will be transfer to this recepient.
      /// @param token Bribe token to redirect
-     /// @param recepeint Address where redirected token will be transferred
+     /// @param recepient Address where redirected token will be transferred
      /// @param redirectionFee Fee to be processed for the redirection service, different per recepient
     function setRedirectionToken(address token, address recepient, uint256 redirectionFee) external {
         _onlyGovernance();

--- a/contracts/MyStrategy.sol
+++ b/contracts/MyStrategy.sol
@@ -386,11 +386,11 @@ contract MyStrategy is BaseStrategy, ReentrancyGuardUpgradeable {
         for (uint256 i = 0; i < numClaims; ++i) {
             (address token, , , ) = hiddenHandDistributor.rewards(_claims[i].identifier);
 
-            address recepient = bribesRedirectionPaths[token];
             if (token == hhBribeVault) {
                 // ETH
                 uint256 difference = address(this).balance.sub(beforeBalance[i]);
                 if (difference > 0) {
+                    address recepient = bribesRedirectionPaths[address(WETH)];
                     IWeth(address(WETH)).deposit{value: difference}();
                     if (recepient == address(0)) {
                         nonZeroDiff = true;
@@ -400,6 +400,7 @@ contract MyStrategy is BaseStrategy, ReentrancyGuardUpgradeable {
             } else {
                 uint256 difference = IERC20Upgradeable(token).balanceOf(address(this)).sub(beforeBalance[i]);
                 if (difference > 0) {
+                    address recepient = bribesRedirectionPaths[token];
                     if (recepient == address(0)) {
                         nonZeroDiff = true;
                     }

--- a/contracts/MyStrategy.sol
+++ b/contracts/MyStrategy.sol
@@ -21,7 +21,12 @@ import {IWeth} from "../interfaces/weth/IWeth.sol";
  * Version 1:
  * - Basic version
  * Version 1.1:
- * Fixes from CodeArena Contest
+ * - Fixes from CodeArena Contest
+ * Version 1.2:
+ * - Removes hardcoded redirection path for BADGER to the BadgerTree
+ * - Introduces bribes redirection paths for certain bribe tokens
+ * - Introduces the bribe redirection fee and processing
+ * - Setter function for the above
  */
 
 contract MyStrategy is BaseStrategy, ReentrancyGuardUpgradeable {
@@ -39,8 +44,6 @@ contract MyStrategy is BaseStrategy, ReentrancyGuardUpgradeable {
     uint256 public auraBalToBalEthBptMinOutBps;
 
     IBalancerVault public constant BALANCER_VAULT = IBalancerVault(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
-
-    address public constant BADGER = 0x3472A5A71965499acd81997a54BBA8D852C6E53d;
 
     IAuraLocker public constant LOCKER = IAuraLocker(0x3Fa73f1E5d8A792C80F426fc8F84FBF7Ce9bBCAC);
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from brownie import (
     MyStrategy,
     TheVault,
     MockRewardDistributor,
+    MockBribesProcessor,
     interface,
     accounts,
     chain,
@@ -245,6 +246,13 @@ def distribute_auraBal(strategy, auraStakingProxy):
 @pytest.fixture
 def reward_distributor(deployer):
     return MockRewardDistributor.deploy({"from": deployer})
+
+
+@pytest.fixture
+def bribes_processor(deployer, strategy, governance):
+    processor = MockBribesProcessor.deploy({"from": deployer})
+    strategy.setBribesProcessor(processor, {"from": governance})
+    return processor
 
 
 ## Forces reset before each test

--- a/tests/integration/test_claim_bribes.py
+++ b/tests/integration/test_claim_bribes.py
@@ -156,12 +156,12 @@ def test_claim_bribes_with_redirection(
     # Setting BADGER to be redirected to deployer with a fee
     strategy.setRedirectionToken(badger, deployer, 1500, {"from": governance})
     assert strategy.bribesRedirectionPaths(badger) == deployer
-    assert strategy.redirectionFees(deployer) == 1500
+    assert strategy.redirectionFees(badger) == 1500
 
     # Calling again for BADGER changes settings to treausury as recepeint and 0 fee
     strategy.setRedirectionToken(badger, treasury, 0, {"from": governance})
     assert strategy.bribesRedirectionPaths(badger) == treasury
-    assert strategy.redirectionFees(treasury) == 0
+    assert strategy.redirectionFees(badger) == 0
 
     # Test invalid settings
     with brownie.reverts("Invalid token address"):
@@ -174,7 +174,7 @@ def test_claim_bribes_with_redirection(
     # Setting GNO to be redirected to its intended recepient with a 15% fee
     strategy.setRedirectionToken(gno, gno_recepient, 1500, {"from": governance})
     assert strategy.bribesRedirectionPaths(gno) == gno_recepient
-    assert strategy.redirectionFees(gno_recepient) == 1500
+    assert strategy.redirectionFees(gno) == 1500
 
     # NOTE: USDC is not redirected
 
@@ -203,7 +203,7 @@ def test_claim_bribes_with_redirection(
     # Check that redirection fee was processed
     event = claim_tx.events["RedirectionFee"]
     assert len(event) == 1 # Only GNO has fees assigned to it
-    expected_fee_amount = gno_amount * strategy.redirectionFees(gno_recepient) / 10000
+    expected_fee_amount = gno_amount * strategy.redirectionFees(gno) / 10000
     assert event["destination"] == treasury
     assert event["token"] == gno
     assert event["amount"] == expected_fee_amount

--- a/tests/integration/test_claim_bribes.py
+++ b/tests/integration/test_claim_bribes.py
@@ -1,6 +1,6 @@
 import pytest
 import brownie
-
+from helpers.constants import AddressZero
 from brownie import (
     accounts,
     interface,
@@ -8,12 +8,21 @@ from brownie import (
     MockBribesProcessor,
 )
 
+# Tokens
 BADGER = "0x3472A5A71965499acd81997a54BBA8D852C6E53d"
+GNO = "0x6810e776880C02933D47DB1b9fc05908e5386b96"
+USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+
+# Whales
 BADGER_WHALE = "0xF977814e90dA44bFA03b6295A0616a897441aceC"
+GNO_WHALE = "0xeC83f750adfe0e52A8b0DbA6eeB6be5Ba0beE535"
+USDC_WHALE = "0x0A59649758aa4d66E25f08Dd01271e891fe52199"
 
 ETH_IDENTIFIER = web3.keccak(text="ETH")
 BADGER_IDENTIFIER = web3.keccak(text="BADGER")
 WANT_IDENTIFIER = web3.keccak(text="WANT")
+GNO_IDENTIFIER = web3.keccak(text="GNO")
+USDC_IDENTIFIER = web3.keccak(text="USDC")
 
 
 @pytest.fixture
@@ -21,6 +30,18 @@ def badger(deployer):
     badger = interface.IERC20Detailed(BADGER)
     badger.transfer(deployer, 100e18, {"from": BADGER_WHALE})
     return badger
+
+@pytest.fixture
+def gno(deployer):
+    gno = interface.IERC20Detailed(GNO)
+    gno.transfer(deployer, 100e18, {"from": GNO_WHALE})
+    return gno
+
+@pytest.fixture
+def usdc(deployer):
+    usdc = interface.IERC20Detailed(USDC)
+    usdc.transfer(deployer, 100e8, {"from": USDC_WHALE})
+    return usdc
 
 
 @pytest.fixture
@@ -31,7 +52,7 @@ def bribes_processor(deployer, strategy, governance):
 
 
 @pytest.fixture(autouse=True)
-def reward_distributor_setup(want, badger, deployer, reward_distributor):
+def reward_distributor_setup(want, badger, gno, usdc, deployer, reward_distributor):
     accounts.at(deployer).transfer(reward_distributor, "1 ether")
 
     reward_distributor.addReward(WANT_IDENTIFIER, want, {"from": deployer})
@@ -41,7 +62,21 @@ def reward_distributor_setup(want, badger, deployer, reward_distributor):
     reward_distributor.addReward(BADGER_IDENTIFIER, badger, {"from": deployer})
     amount = badger.balanceOf(deployer) // 2
     badger.transfer(reward_distributor, amount, {"from": deployer})
+
+    reward_distributor.addReward(GNO_IDENTIFIER, gno, {"from": deployer})
+    amount = badger.balanceOf(deployer) // 2
+    gno.transfer(reward_distributor, amount, {"from": deployer})
+
+    reward_distributor.addReward(USDC_IDENTIFIER, usdc, {"from": deployer})
+    amount = usdc.balanceOf(deployer) // 2
+    usdc.transfer(reward_distributor, amount, {"from": deployer})
+
     return reward_distributor
+
+
+@pytest.fixture
+def gno_recepient():
+    return accounts[7]
 
 
 def test_claim_bribes(want, strategy, bribes_processor, reward_distributor, strategist, deployer):
@@ -62,26 +97,6 @@ def test_claim_bribes(want, strategy, bribes_processor, reward_distributor, stra
 
     assert claim_tx.events["RewardsCollected"]["token"] == want
     assert claim_tx.events["RewardsCollected"]["amount"] == amount
-
-
-def test_claim_bribes_badger(badger, badgerTree, strategy, reward_distributor, bribes_processor, strategist, deployer):
-    balance_before = badger.balanceOf(badgerTree)
-
-    amount = badger.balanceOf(deployer) // 2
-    assert amount > 0
-
-    claim_tx = strategy.claimBribesFromHiddenHand(
-        reward_distributor,
-        [
-            (BADGER_IDENTIFIER, strategy, amount, [])
-        ],
-        {"from": strategist}
-    )
-
-    assert badger.balanceOf(badgerTree) == balance_before + amount
-
-    assert claim_tx.events["TreeDistribution"]["token"] == badger
-    assert claim_tx.events["TreeDistribution"]["amount"] == amount
 
 
 def test_claim_eth_bribes(strategy, strategist, bribes_processor, reward_distributor):
@@ -130,3 +145,79 @@ def test_bribe_claiming_no_processor(want, deployer, strategy, strategist, rewar
             ],
             {"from": strategist}
         )
+
+def test_claim_bribes_with_redirection(
+    badger,
+    gno,
+    usdc, 
+    gno_recepient,
+    vault, 
+    strategy,
+    reward_distributor,
+    bribes_processor,
+    strategist, 
+    deployer,
+    governance
+):
+    treasury = vault.treasury()
+
+    # Setting BADGER to be redirected to deployer with a fee
+    strategy.setRedirectionToken(badger, deployer, 1500, {"from": governance})
+    assert strategy.bribesRedirectionPaths(badger) == deployer
+    assert strategy.redirectionFees(deployer) == 1500
+
+    # Calling again for BADGER changes settings to treausury as recepeint and 0 fee
+    strategy.setRedirectionToken(badger, treasury, 0, {"from": governance})
+    assert strategy.bribesRedirectionPaths(badger) == treasury
+    assert strategy.redirectionFees(treasury) == 0
+
+    # Test invalid settings
+    with brownie.reverts("Invalid token address"):
+        strategy.setRedirectionToken(AddressZero, treasury, 0, {"from": governance})
+    with brownie.reverts("Invalid recepient address"):
+        strategy.setRedirectionToken(badger, AddressZero, 0, {"from": governance})
+    with brownie.reverts("Invalid redirection fee"):
+        strategy.setRedirectionToken(badger, treasury, 20000, {"from": governance})
+
+    # Setting GNO to be redirected to its intended recepient with a 15% fee
+    strategy.setRedirectionToken(gno, gno_recepient, 1500, {"from": governance})
+    assert strategy.bribesRedirectionPaths(gno) == gno_recepient
+    assert strategy.redirectionFees(gno_recepient) == 1500
+
+    # NOTE: USDC is not redirected
+
+    badger_amount = badger.balanceOf(reward_distributor)
+    gno_amount = gno.balanceOf(reward_distributor)
+    usdc_amount = usdc.balanceOf(reward_distributor)
+    assert badger_amount > 0
+    assert gno_amount > 0
+    assert usdc_amount > 0
+
+    badger_recepient_balance_before = badger.balanceOf(treasury)
+    gno_recepient_balance_before = gno.balanceOf(gno_recepient)
+    usdc_processor_balance_before = usdc.balanceOf(bribes_processor)
+
+    # Batch claim tokens
+    claim_tx = strategy.claimBribesFromHiddenHand(
+        reward_distributor,
+        [
+            (BADGER_IDENTIFIER, strategy, badger_amount, []),
+            (GNO_IDENTIFIER, strategy, gno_amount, []),
+            (USDC_IDENTIFIER, strategy, usdc_amount, []),
+        ],
+        {"from": strategist}
+    )
+
+    # Check that redirection fee was processed
+    event = claim_tx.events["RedirectionFee"]
+    assert len(event) == 1 # Only GNO has fees assigned to it
+    expected_fee_amount = gno_amount * strategy.redirectionFees(gno_recepient) / 10000
+    assert event["destination"] == treasury
+    assert event["token"] == gno
+    assert event["amount"] == expected_fee_amount
+    assert gno.balanceOf(treasury) == expected_fee_amount
+
+    # Check accounting
+    assert badger.balanceOf(treasury) == badger_recepient_balance_before + badger_amount
+    assert gno.balanceOf(gno_recepient) == gno_recepient_balance_before + gno_amount - expected_fee_amount
+    assert usdc.balanceOf(bribes_processor) == usdc_processor_balance_before + usdc_amount

--- a/tests/integration/test_claim_bribes.py
+++ b/tests/integration/test_claim_bribes.py
@@ -217,6 +217,18 @@ def test_claim_bribes_with_redirection(
     assert event["amount"] == expected_fee_amount
     assert gno.balanceOf(treasury) == expected_fee_amount
 
+    # Check that the TokenRedirection event was emitted
+    event = claim_tx.events["TokenRedirection"]
+    assert len(event) == 2
+    # Confirm BADGER event
+    assert event[0]["destination"] == treasury
+    assert event[0]["token"] == badger
+    assert event[0]["amount"] == badger_amount
+    # Confirm GNO event
+    assert event[1]["destination"] == gno_recepient
+    assert event[1]["token"] == gno
+    assert event[1]["amount"] == gno_recepient_balance_before + gno_amount - expected_fee_amount
+
     # Check accounting
     assert badger.balanceOf(treasury) == badger_recepient_balance_before + badger_amount
     assert gno.balanceOf(gno_recepient) == gno_recepient_balance_before + gno_amount - expected_fee_amount

--- a/tests/integration/test_claim_bribes.py
+++ b/tests/integration/test_claim_bribes.py
@@ -4,8 +4,7 @@ from helpers.constants import AddressZero
 from brownie import (
     accounts,
     interface,
-    web3,
-    MockBribesProcessor,
+    web3
 )
 
 # Tokens
@@ -42,13 +41,6 @@ def usdc(deployer):
     usdc = interface.IERC20Detailed(USDC)
     usdc.transfer(deployer, 100e8, {"from": USDC_WHALE})
     return usdc
-
-
-@pytest.fixture
-def bribes_processor(deployer, strategy, governance):
-    processor = MockBribesProcessor.deploy({"from": deployer})
-    strategy.setBribesProcessor(processor, {"from": governance})
-    return processor
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_claim_bribes.py
+++ b/tests/integration/test_claim_bribes.py
@@ -42,6 +42,14 @@ def usdc(deployer):
     usdc.transfer(deployer, 100e8, {"from": USDC_WHALE})
     return usdc
 
+@pytest.fixture
+def weth(deployer, strategy):
+    amount = 1e18
+    weth = interface.IWeth(strategy.WETH())
+    weth.deposit({"from": deployer, "value": amount})
+    weth = interface.IERC20Detailed(weth.address)
+    return weth
+
 
 @pytest.fixture(autouse=True)
 def reward_distributor_setup(want, badger, gno, usdc, deployer, reward_distributor):
@@ -56,7 +64,7 @@ def reward_distributor_setup(want, badger, gno, usdc, deployer, reward_distribut
     badger.transfer(reward_distributor, amount, {"from": deployer})
 
     reward_distributor.addReward(GNO_IDENTIFIER, gno, {"from": deployer})
-    amount = badger.balanceOf(deployer) // 2
+    amount = gno.balanceOf(deployer) // 2
     gno.transfer(reward_distributor, amount, {"from": deployer})
 
     reward_distributor.addReward(USDC_IDENTIFIER, usdc, {"from": deployer})
@@ -69,6 +77,10 @@ def reward_distributor_setup(want, badger, gno, usdc, deployer, reward_distribut
 @pytest.fixture
 def gno_recepient():
     return accounts[7]
+
+@pytest.fixture
+def weth_recepient():
+    return accounts[9]
 
 
 def test_claim_bribes(want, strategy, bribes_processor, reward_distributor, strategist, deployer):
@@ -109,13 +121,8 @@ def test_claim_eth_bribes(strategy, strategist, bribes_processor, reward_distrib
     assert claim_tx.events["RewardsCollected"]["amount"] == amount
 
 
-def test_sweep_weth(strategy, strategist, bribes_processor, deployer):
+def test_sweep_weth(strategy, strategist, bribes_processor, deployer, weth):
     amount = 1e18
-
-    weth = interface.IWeth(strategy.WETH())
-    weth.deposit({"from": deployer, "value": amount})
-
-    weth = interface.IERC20Detailed(weth.address)
     weth.transfer(strategy, amount, {"from": deployer})
 
     balance_before_proc = weth.balanceOf(bribes_processor)
@@ -141,8 +148,10 @@ def test_bribe_claiming_no_processor(want, deployer, strategy, strategist, rewar
 def test_claim_bribes_with_redirection(
     badger,
     gno,
-    usdc, 
+    usdc,
+    weth,
     gno_recepient,
+    weth_recepient,
     vault, 
     strategy,
     reward_distributor,
@@ -176,17 +185,25 @@ def test_claim_bribes_with_redirection(
     assert strategy.bribesRedirectionPaths(gno) == gno_recepient
     assert strategy.redirectionFees(gno) == 1500
 
+    # Setting ETH to be redirected to its intended recepient with a 10% fee
+    strategy.setRedirectionToken(weth, weth_recepient, 1000, {"from": governance})
+    assert strategy.bribesRedirectionPaths(weth) == weth_recepient
+    assert strategy.redirectionFees(weth) == 1000
+
     # NOTE: USDC is not redirected
 
     badger_amount = badger.balanceOf(reward_distributor)
     gno_amount = gno.balanceOf(reward_distributor)
     usdc_amount = usdc.balanceOf(reward_distributor)
+    eth_amount = reward_distributor.balance()
     assert badger_amount > 0
     assert gno_amount > 0
     assert usdc_amount > 0
+    assert eth_amount > 0
 
     badger_recepient_balance_before = badger.balanceOf(treasury)
     gno_recepient_balance_before = gno.balanceOf(gno_recepient)
+    weth_recepient_balance_before = weth.balanceOf(weth_recepient)
     usdc_processor_balance_before = usdc.balanceOf(bribes_processor)
 
     # Batch claim tokens
@@ -196,22 +213,30 @@ def test_claim_bribes_with_redirection(
             (BADGER_IDENTIFIER, strategy, badger_amount, []),
             (GNO_IDENTIFIER, strategy, gno_amount, []),
             (USDC_IDENTIFIER, strategy, usdc_amount, []),
+            (ETH_IDENTIFIER, strategy, eth_amount, [])
         ],
         {"from": strategist}
     )
 
     # Check that redirection fee was processed
     event = claim_tx.events["RedirectionFee"]
-    assert len(event) == 1 # Only GNO has fees assigned to it
-    expected_fee_amount = gno_amount * strategy.redirectionFees(gno) / 10000
-    assert event["destination"] == treasury
-    assert event["token"] == gno
-    assert event["amount"] == expected_fee_amount
-    assert gno.balanceOf(treasury) == expected_fee_amount
+    assert len(event) == 2 # Both GNO and ETH have fees assigned to them
+    # Confirm GNO event
+    expected_gno_fee_amount = gno_amount * strategy.redirectionFees(gno) / 10000
+    assert event[0]["destination"] == treasury
+    assert event[0]["token"] == gno
+    assert event[0]["amount"] == expected_gno_fee_amount
+    assert gno.balanceOf(treasury) == expected_gno_fee_amount
+    # Confirm ETH event
+    expected_weth_fee_amount = eth_amount * strategy.redirectionFees(weth) / 10000
+    assert event[1]["destination"] == treasury
+    assert event[1]["token"] == weth
+    assert event[1]["amount"] == expected_weth_fee_amount
+    assert weth.balanceOf(treasury) == expected_weth_fee_amount
 
     # Check that the TokenRedirection event was emitted
     event = claim_tx.events["TokenRedirection"]
-    assert len(event) == 2
+    assert len(event) == 3
     # Confirm BADGER event
     assert event[0]["destination"] == treasury
     assert event[0]["token"] == badger
@@ -219,9 +244,14 @@ def test_claim_bribes_with_redirection(
     # Confirm GNO event
     assert event[1]["destination"] == gno_recepient
     assert event[1]["token"] == gno
-    assert event[1]["amount"] == gno_recepient_balance_before + gno_amount - expected_fee_amount
+    assert event[1]["amount"] == gno_recepient_balance_before + gno_amount - expected_gno_fee_amount
+    # Confirm ETH event
+    assert event[2]["destination"] == weth_recepient
+    assert event[2]["token"] == weth
+    assert event[2]["amount"] == weth_recepient_balance_before + eth_amount - expected_weth_fee_amount
 
     # Check accounting
     assert badger.balanceOf(treasury) == badger_recepient_balance_before + badger_amount
-    assert gno.balanceOf(gno_recepient) == gno_recepient_balance_before + gno_amount - expected_fee_amount
+    assert gno.balanceOf(gno_recepient) == gno_recepient_balance_before + gno_amount - expected_gno_fee_amount
+    assert weth.balanceOf(weth_recepient) == weth_recepient_balance_before + eth_amount - expected_weth_fee_amount
     assert usdc.balanceOf(bribes_processor) == usdc_processor_balance_before + usdc_amount

--- a/tests/integration/test_strategy_permissions.py
+++ b/tests/integration/test_strategy_permissions.py
@@ -108,6 +108,46 @@ def test_strategy_action_permissions(
             with brownie.reverts("onlyGovernanceOrStrategist"):
                 vault.sweepExtraToken(vault, {"from": actor})
 
+    # setRedirectionToken
+    for actor in actorsToCheck:
+        if actor == strategy.governance():
+            strategy.setRedirectionToken(want, deployer, 1500, {"from": actor})
+        else:
+            with brownie.reverts("onlyGovernance"):
+                strategy.setRedirectionToken(want, deployer, 1500, {"from": actor})
+
+    # setBribesProcessor
+    for actor in actorsToCheck:
+        if actor == strategy.governance():
+            strategy.setBribesProcessor(accounts[5], {"from": actor})
+        else:
+            with brownie.reverts("onlyGovernance"):
+                strategy.setBribesProcessor(accounts[5], {"from": actor})
+
+    # setProcessLocksOnReinvest
+    for actor in actorsToCheck:
+        if actor == strategy.governance():
+            strategy.setProcessLocksOnReinvest(False, {"from": actor})
+        else:
+            with brownie.reverts("onlyGovernance"):
+                strategy.setProcessLocksOnReinvest(False, {"from": actor})
+
+    # setWithdrawalSafetyCheck
+    for actor in actorsToCheck:
+        if actor == strategy.governance():
+            strategy.setWithdrawalSafetyCheck(False, {"from": actor})
+        else:
+            with brownie.reverts("onlyGovernance"):
+                strategy.setWithdrawalSafetyCheck(False, {"from": actor})
+
+    # setWithdrawalSafetyCheck
+    for actor in actorsToCheck:
+        if actor == strategy.governance():
+            strategy.manualSetDelegate(deployer, {"from": actor})
+        else:
+            with brownie.reverts("onlyGovernance"):
+                strategy.manualSetDelegate(deployer, {"from": actor})
+
 
 def test_strategy_pausing_permissions(deployer, vault, strategy, want, keeper):
     # Setup

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -10,8 +10,8 @@ from helpers.time import days
   See test_strategy_permissions, for tests at the permissions level
 """
 
-CVX_FXS = "0xFEEf77d3f69374f66429C91d732A244f074bdf74"
-CVX_FXS_WHALE = "0xd658A338613198204DCa1143Ac3F01A722b5d94A"
+BB_A_USD = "0x7B50775383d3D6f0215A8F290f2C9e2eEBBEceb2"
+BB_A_USD_WHALE = "0xBA12222222228d8Ba445958a75a0704d566BF2C8"
 
 def test_after_wait_withdrawSome_unlocks_for_caller(setup_strat, want, vault, deployer):
     ## Try to withdraw all, fail because locked
@@ -194,15 +194,33 @@ def test_cant_sweep_want(want, strategy, strategist):
 
 def test_sweep_rewards(strategy, strategist, bribes_processor):
     # Transfer exra reward tokens to the strategy
-    amount = 100e18
-    cvxFxs = interface.IERC20Detailed(CVX_FXS)
-    whale = accounts.at(CVX_FXS_WHALE, force=True)
-    cvxFxs.transfer(strategy, amount, {"from": whale})
+    amount = 1000e18
+    bbausd = interface.IERC20Detailed(BB_A_USD)
+    whale = accounts.at(BB_A_USD_WHALE, force=True)
+    bbausd.transfer(strategy, amount, {"from": whale})
 
     # A non protected token can be swept
-    balance_processor_before = cvxFxs.balanceOf(bribes_processor)
-    strategy.sweepRewardToken(cvxFxs, {"from": strategist})
-    assert cvxFxs.balanceOf(bribes_processor) == balance_processor_before + amount
+    balance_processor_before = bbausd.balanceOf(bribes_processor)
+    strategy.sweepRewardToken(bbausd, {"from": strategist})
+    assert bbausd.balanceOf(bribes_processor) == balance_processor_before + amount
+
+
+def test_sweep_rewards_with_redirection(strategy, strategist, governance, bribes_processor):
+    # Transfer exra reward tokens to the strategy
+    amount = 1000e18
+    bbausd = interface.IERC20Detailed(BB_A_USD)
+    whale = accounts.at(BB_A_USD_WHALE, force=True)
+    bbausd.transfer(strategy, amount, {"from": whale})
+
+    # Set redirection path (no fee for simplicity)
+    strategy.setRedirectionToken(bbausd, strategist, 0, {"from": governance})
+    assert strategy.bribesRedirectionPaths(bbausd) == strategist
+    assert strategy.redirectionFees(bbausd) == 0
+
+    # A non protected token can be swept to its redirection recepient
+    balance_recepient_before = bbausd.balanceOf(strategist)
+    strategy.sweepRewardToken(bbausd, {"from": strategist})
+    assert bbausd.balanceOf(strategist) == balance_recepient_before + amount
 
 
 def test_cant_take_eth(deployer, strategy):

--- a/tests/upgrade/test_upgrade.py
+++ b/tests/upgrade/test_upgrade.py
@@ -37,9 +37,6 @@ def test_check_storage_integrity(strat_proxy, vault_proxy, deployer, proxy_admin
     old_processLocksOnReinvest = strat_proxy.processLocksOnReinvest()
     old_bribesProcessor = strat_proxy.bribesProcessor()
     old_auraBalToBalEthBptMinOutBps = strat_proxy.auraBalToBalEthBptMinOutBps()
-    
-    with brownie.reverts():
-        strat_proxy.auraBalToBalEthBptMinOutBps()
 
     logic = MyStrategy.deploy({"from": deployer})
 

--- a/tests/upgrade/test_upgrade.py
+++ b/tests/upgrade/test_upgrade.py
@@ -36,39 +36,28 @@ def test_check_storage_integrity(strat_proxy, vault_proxy, deployer, proxy_admin
     old_withdrawalSafetyCheck = strat_proxy.withdrawalSafetyCheck()
     old_processLocksOnReinvest = strat_proxy.processLocksOnReinvest()
     old_bribesProcessor = strat_proxy.bribesProcessor()
+    old_auraBalToBalEthBptMinOutBps = strat_proxy.auraBalToBalEthBptMinOutBps()
     
     with brownie.reverts():
         strat_proxy.auraBalToBalEthBptMinOutBps()
 
-    logics = [
-        MyStrategy.deploy({"from": deployer}), 
-        MyStrategy.at("0x0d724E8AEE6F73b35A596C8C947c92c75eAc7818")
-    ]
+    logic = MyStrategy.deploy({"from": deployer})
 
-    chain.snapshot()
-    for new_strat_logic in logics:
-        ## Do the Upgrade
-        proxy_admin.upgrade(strat_proxy, new_strat_logic, {"from": proxy_admin_gov})
+    ## Do the Upgrade
+    proxy_admin.upgrade(strat_proxy, logic, {"from": proxy_admin_gov})
 
-        ## Check Integrity
-        assert old_want == strat_proxy.want()
-        assert old_vault == strat_proxy.vault()
-        assert old_withdrawalMaxDeviationThreshold == strat_proxy.withdrawalMaxDeviationThreshold()
-        assert old_autoCompoundRatio == strat_proxy.autoCompoundRatio()
-        assert old_withdrawalSafetyCheck == strat_proxy.withdrawalSafetyCheck()
-        assert old_processLocksOnReinvest == strat_proxy.processLocksOnReinvest()
-        assert old_bribesProcessor == strat_proxy.bribesProcessor()
+    ## Check Integrity
+    assert old_want == strat_proxy.want()
+    assert old_vault == strat_proxy.vault()
+    assert old_withdrawalMaxDeviationThreshold == strat_proxy.withdrawalMaxDeviationThreshold()
+    assert old_autoCompoundRatio == strat_proxy.autoCompoundRatio()
+    assert old_withdrawalSafetyCheck == strat_proxy.withdrawalSafetyCheck()
+    assert old_processLocksOnReinvest == strat_proxy.processLocksOnReinvest()
+    assert old_bribesProcessor == strat_proxy.bribesProcessor()
+    assert old_auraBalToBalEthBptMinOutBps == strat_proxy.auraBalToBalEthBptMinOutBps()
 
-        assert strat_proxy.auraBalToBalEthBptMinOutBps() == 0
+    gov = accounts.at(vault_proxy.governance(), force=True)
 
-        gov = accounts.at(vault_proxy.governance(), force=True)
-
-        # Set slippage tolerance
-        strat_proxy.setAuraBalToBalEthBptMinOutBps(9500, {"from": gov})
-        assert strat_proxy.auraBalToBalEthBptMinOutBps() == 9500
-
-        ## Let's do a quick earn and harvest as well
-        vault_proxy.earn({"from": gov})
-        strat_proxy.harvest({"from": gov})
-
-        chain.revert()
+    ## Let's do a quick earn and harvest as well
+    vault_proxy.earn({"from": gov})
+    strat_proxy.harvest({"from": gov})


### PR DESCRIPTION
## Version 1.2: Bribes Redirection

### Changes introduced
- Removed hardcoded redirection of BADGER to BadgerTree
- Mapping of tokens to be redirected to their respective destinations and the redirection fees to be processed for each of these paths. This is maintainable by governance.
- Any token added to the list mentioned above will be redirected upon bribes claiming after its fee is processed, otherwise they will be sent to the BribesProcessor directly
- Events were included for the token redirections (to better inform of on-chain operations to partner DAOs and our treasury) and the redirection fees (to help track revenue streams).
- All of the above was tested including the upgrade storage integrity (additional missing tests were also introduced for the sweeping of rewards and some of the permissions)

### Notes
- As per discussions with @Tritium-VLK, it was decided to not introduce the redirection split feature as it is highly unlikely to be utilized and adding it meant a significant amount added of manual maintenance work for every bribes round as well as meaningful gas usage increase.
- The current setup allows for simple redirections of certain rewards to certain destinations and fee processing for this service. This should be enough given that HiddenHands will soon implement a whitelist to only allow our parterns to bribe with their token. While this list gets implemented, it is still unlikely for a random briber to bribe using another DAO's token and, if they do, it is highly unlikely that the amounts will be significant enough for it to justify the bi-weekly extra work + gas expenditure. It will be communicated and made clear enough that bribes set to be redirected will do so for the total amount obtained by graviAURA
- ETH can't be redirected (wouldn't make sense anyway)
- Redirection fee can be anything between 0 and 100%, do we want to hardcode a cap?

### Testing
All tests are passing:
![image](https://user-images.githubusercontent.com/25463788/186025979-2d473d5b-86b7-4961-bd5e-09540f074918.png)
![image](https://user-images.githubusercontent.com/25463788/186026048-fe5a3330-1766-498e-bff4-659b6a1b042e.png)
