### PR TITLE
snapshot delegation

### DIFF
--- a/interfaces/snapshot/IDelegateRegistry.sol
+++ b/interfaces/snapshot/IDelegateRegistry.sol
@@ -5,5 +5,5 @@ pragma solidity 0.6.12;
 interface IDelegateRegistry {
     function setDelegate(bytes32 id, address delegate) external;
 
-    function delegation(address, bytes32) external returns (address);
+    function delegation(address, bytes32) external view returns (address);
 }


### PR DESCRIPTION
Add the ability to delegate on arbitrary snapshot space IDs to [support current voting developments](https://github.com/Badger-Finance/Badger-Project-Planning/issues/84).

# New Functions
Get and set snapshot delegation on an arbitrary space ID
`setSnapshotDelegate(bytes32 id, address delegate) external`
`getSnapshotDelegate(bytes32 id) external view returns (address)`

Naming modifications for clarity on aura locker delegation, relative to above

