### PR TITLE
Patch graviAURA strategy to HiddenHand's V2 Changes

### DIFF
--- a/contracts/MyStrategy.sol
+++ b/contracts/MyStrategy.sol
@@ -29,6 +29,9 @@ import {IDelegateRegistry} from "../interfaces/snapshot/IDelegateRegistry.sol";
  * - Introduces the bribe redirection fee and processing
  * - Introduces a setter function for the above
  * - Introduces snapshot delegation
+ * Version 1.3:
+ * - Removes ETH Incentives special case handling
+ * - Linting fixes
  */
 
 contract MyStrategy is BaseStrategy, ReentrancyGuardUpgradeable {
@@ -200,7 +203,7 @@ contract MyStrategy is BaseStrategy, ReentrancyGuardUpgradeable {
 
     /// @dev Specify the version of the Strategy, for upgrades
     function version() external pure returns (string memory) {
-        return "1.2";
+        return "1.3";
     }
 
     /// @dev Does this function require `tend` to be called?

--- a/contracts/mocks/MockRewardDistributor.sol
+++ b/contracts/mocks/MockRewardDistributor.sol
@@ -10,9 +10,6 @@ import {IRewardDistributor} from "../../interfaces/hiddenhand/IRewardDistributor
 contract MockRewardDistributor {
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
-    address constant public BRIBE_VAULT = address(1);
-    bytes32 constant private ETH_IDENTIFIER = keccak256("ETH");
-
     mapping(bytes32 => address) public mockRewards;
 
     function addReward(bytes32 _identifier, address _token) external {
@@ -28,24 +25,14 @@ contract MockRewardDistributor {
             bytes32 proof,
             uint256 updateCount
         ) {
-        if (_identifier == ETH_IDENTIFIER) {
-            token = BRIBE_VAULT;
-        } else {
-            token = mockRewards[_identifier];
-        }
+        token = mockRewards[_identifier];
     }
 
     function claim(IRewardDistributor.Claim[] memory _claims) external {
         for (uint256 i; i < _claims.length; ++i) {
             IRewardDistributor.Claim memory claim = _claims[i];
-
-            if (claim.identifier == ETH_IDENTIFIER) {
-                (bool sent, ) = payable(claim.account).call{value: claim.amount}("");
-                require(sent, "Transfer failed");
-            } else {
-                IERC20Upgradeable token = IERC20Upgradeable(mockRewards[claim.identifier]);
-                token.safeTransfer(claim.account, claim.amount);
-            }
+            IERC20Upgradeable token = IERC20Upgradeable(mockRewards[claim.identifier]);
+            token.safeTransfer(claim.account, claim.amount);
         }
     }
 

--- a/contracts/mocks/MockRewardDistributor.sol
+++ b/contracts/mocks/MockRewardDistributor.sol
@@ -24,7 +24,8 @@ contract MockRewardDistributor {
             bytes32 merkleRoot,
             bytes32 proof,
             uint256 updateCount
-        ) {
+        )
+    {
         token = mockRewards[_identifier];
     }
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,5 @@
+[profile.default]
+remappings = [
+    "@openzeppelin-contracts-upgradeable=/root/.brownie/packages/OpenZeppelin/openzeppelin-contracts-upgradeable@3.4.0/contracts/",
+    "@badger-finance=/root/.brownie/packages/Badger-Finance/badger-vaults-1.5@0.1.1/contracts/",
+]

--- a/interfaces/aura/IAuraLocker.sol
+++ b/interfaces/aura/IAuraLocker.sol
@@ -62,7 +62,6 @@ interface IAuraLocker {
 
     function lockedSupply() external view returns (uint256);
 
-
     // Withdraw/relock all currently locked tokens where the unlock time has passed
     function processExpiredLocks(
         bool _relock,

--- a/interfaces/aura/IAuraStakingProxy.sol
+++ b/interfaces/aura/IAuraStakingProxy.sol
@@ -5,8 +5,10 @@ interface IAuraStakingProxy {
     function owner() external view returns (address);
 
     function keeper() external view returns (address);
+
     function setKeeper(address _keeper) external;
 
     function distribute(uint256 _minOut) external;
+
     function distribute() external;
 }

--- a/interfaces/weth/IWeth.sol
+++ b/interfaces/weth/IWeth.sol
@@ -4,4 +4,3 @@ pragma solidity 0.6.12;
 interface IWeth {
     function deposit() external payable;
 }
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from brownie import (
     interface,
     accounts,
     chain,
-    Contract
+    Contract,
 )
 from _setup.config import (
     WANT,
@@ -38,9 +38,11 @@ def deployer():
 def user():
     return accounts[9]
 
+
 @pytest.fixture
 def delegation_registry():
     return Contract.from_explorer("0x469788fE6E9E9681C6ebF3bF78e7Fd26Fc015446")
+
 
 ## Fund the account
 @pytest.fixture
@@ -198,7 +200,6 @@ def auraStakingProxy():
 
 @pytest.fixture
 def setup_share_math(deployer, vault, want, governance):
-
     depositAmount = int(want.balanceOf(deployer) * 0.5)
     assert depositAmount > 0
     want.approve(vault.address, MaxUint256, {"from": deployer})
@@ -244,7 +245,7 @@ def distribute_auraBal(strategy, auraStakingProxy):
 
     # auraStakingProxy.setKeeper(keeper, {"from": })
     # auraStakingProxy.distribute(1, {'from': keeper})
-    auraStakingProxy.distribute({'from': auraStakingProxy.keeper()})
+    auraStakingProxy.distribute({"from": auraStakingProxy.keeper()})
 
 
 @pytest.fixture

--- a/tests/integration/test_claim_bribes.py
+++ b/tests/integration/test_claim_bribes.py
@@ -17,7 +17,7 @@ BADGER_WHALE = "0xF977814e90dA44bFA03b6295A0616a897441aceC"
 GNO_WHALE = "0xeC83f750adfe0e52A8b0DbA6eeB6be5Ba0beE535"
 USDC_WHALE = "0x0A59649758aa4d66E25f08Dd01271e891fe52199"
 
-ETH_IDENTIFIER = web3.keccak(text="ETH")
+WETH_IDENTIFIER = web3.keccak(text="WETH")
 BADGER_IDENTIFIER = web3.keccak(text="BADGER")
 WANT_IDENTIFIER = web3.keccak(text="WANT")
 GNO_IDENTIFIER = web3.keccak(text="GNO")
@@ -44,7 +44,7 @@ def usdc(deployer):
 
 @pytest.fixture
 def weth(deployer, strategy):
-    amount = 1e18
+    amount = 2e18
     weth = interface.IWeth(strategy.WETH())
     weth.deposit({"from": deployer, "value": amount})
     weth = interface.IERC20Detailed(weth.address)
@@ -52,7 +52,7 @@ def weth(deployer, strategy):
 
 
 @pytest.fixture(autouse=True)
-def reward_distributor_setup(want, badger, gno, usdc, deployer, reward_distributor):
+def reward_distributor_setup(want, badger, gno, usdc, weth, deployer, reward_distributor):
     accounts.at(deployer).transfer(reward_distributor, "1 ether")
 
     reward_distributor.addReward(WANT_IDENTIFIER, want, {"from": deployer})
@@ -70,6 +70,10 @@ def reward_distributor_setup(want, badger, gno, usdc, deployer, reward_distribut
     reward_distributor.addReward(USDC_IDENTIFIER, usdc, {"from": deployer})
     amount = usdc.balanceOf(deployer) // 2
     usdc.transfer(reward_distributor, amount, {"from": deployer})
+
+    reward_distributor.addReward(WETH_IDENTIFIER, weth, {"from": deployer})
+    amount = weth.balanceOf(deployer) // 2
+    weth.transfer(reward_distributor, amount, {"from": deployer})
 
     return reward_distributor
 
@@ -111,7 +115,7 @@ def test_claim_eth_bribes(strategy, strategist, bribes_processor, reward_distrib
 
     claim_tx = strategy.claimBribesFromHiddenHand(
         reward_distributor,
-        [(ETH_IDENTIFIER, strategy, amount, [])],
+        [(WETH_IDENTIFIER, strategy, amount, [])],
         {"from": strategist}
     )
 
@@ -213,7 +217,7 @@ def test_claim_bribes_with_redirection(
             (BADGER_IDENTIFIER, strategy, badger_amount, []),
             (GNO_IDENTIFIER, strategy, gno_amount, []),
             (USDC_IDENTIFIER, strategy, usdc_amount, []),
-            (ETH_IDENTIFIER, strategy, eth_amount, [])
+            (WETH_IDENTIFIER, strategy, eth_amount, [])
         ],
         {"from": strategist}
     )

--- a/tests/integration/test_claim_bribes.py
+++ b/tests/integration/test_claim_bribes.py
@@ -80,12 +80,12 @@ def reward_distributor_setup(
 
 
 @pytest.fixture
-def gno_recepient():
+def gno_recipient():
     return accounts[7]
 
 
 @pytest.fixture
-def weth_recepient():
+def weth_recipient():
     return accounts[9]
 
 
@@ -161,8 +161,8 @@ def test_claim_bribes_with_redirection(
     gno,
     usdc,
     weth,
-    gno_recepient,
-    weth_recepient,
+    gno_recipient,
+    weth_recipient,
     vault,
     strategy,
     reward_distributor,
@@ -191,14 +191,14 @@ def test_claim_bribes_with_redirection(
     with brownie.reverts("Invalid redirection fee"):
         strategy.setRedirectionToken(badger, treasury, 20000, {"from": governance})
 
-    # Setting GNO to be redirected to its intended recepient with a 15% fee
-    strategy.setRedirectionToken(gno, gno_recepient, 1500, {"from": governance})
-    assert strategy.bribesRedirectionPaths(gno) == gno_recepient
+    # Setting GNO to be redirected to its intended recipient with a 15% fee
+    strategy.setRedirectionToken(gno, gno_recipient, 1500, {"from": governance})
+    assert strategy.bribesRedirectionPaths(gno) == gno_recipient
     assert strategy.redirectionFees(gno) == 1500
 
-    # Setting ETH to be redirected to its intended recepient with a 10% fee
-    strategy.setRedirectionToken(weth, weth_recepient, 1000, {"from": governance})
-    assert strategy.bribesRedirectionPaths(weth) == weth_recepient
+    # Setting ETH to be redirected to its intended recipient with a 10% fee
+    strategy.setRedirectionToken(weth, weth_recipient, 1000, {"from": governance})
+    assert strategy.bribesRedirectionPaths(weth) == weth_recipient
     assert strategy.redirectionFees(weth) == 1000
 
     # NOTE: USDC is not redirected
@@ -212,9 +212,9 @@ def test_claim_bribes_with_redirection(
     assert usdc_amount > 0
     assert eth_amount > 0
 
-    badger_recepient_balance_before = badger.balanceOf(treasury)
-    gno_recepient_balance_before = gno.balanceOf(gno_recepient)
-    weth_recepient_balance_before = weth.balanceOf(weth_recepient)
+    badger_recipient_balance_before = badger.balanceOf(treasury)
+    gno_recipient_balance_before = gno.balanceOf(gno_recipient)
+    weth_recipient_balance_before = weth.balanceOf(weth_recipient)
     usdc_processor_balance_before = usdc.balanceOf(bribes_processor)
 
     # Batch claim tokens
@@ -253,29 +253,29 @@ def test_claim_bribes_with_redirection(
     assert event[0]["token"] == badger
     assert event[0]["amount"] == badger_amount
     # Confirm GNO event
-    assert event[1]["destination"] == gno_recepient
+    assert event[1]["destination"] == gno_recipient
     assert event[1]["token"] == gno
     assert (
         event[1]["amount"]
-        == gno_recepient_balance_before + gno_amount - expected_gno_fee_amount
+        == gno_recipient_balance_before + gno_amount - expected_gno_fee_amount
     )
     # Confirm ETH event
-    assert event[2]["destination"] == weth_recepient
+    assert event[2]["destination"] == weth_recipient
     assert event[2]["token"] == weth
     assert (
         event[2]["amount"]
-        == weth_recepient_balance_before + eth_amount - expected_weth_fee_amount
+        == weth_recipient_balance_before + eth_amount - expected_weth_fee_amount
     )
 
     # Check accounting
-    assert badger.balanceOf(treasury) == badger_recepient_balance_before + badger_amount
+    assert badger.balanceOf(treasury) == badger_recipient_balance_before + badger_amount
     assert (
-        gno.balanceOf(gno_recepient)
-        == gno_recepient_balance_before + gno_amount - expected_gno_fee_amount
+        gno.balanceOf(gno_recipient)
+        == gno_recipient_balance_before + gno_amount - expected_gno_fee_amount
     )
     assert (
-        weth.balanceOf(weth_recepient)
-        == weth_recepient_balance_before + eth_amount - expected_weth_fee_amount
+        weth.balanceOf(weth_recipient)
+        == weth_recipient_balance_before + eth_amount - expected_weth_fee_amount
     )
     assert (
         usdc.balanceOf(bribes_processor) == usdc_processor_balance_before + usdc_amount

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -13,6 +13,7 @@ from helpers.time import days
 BB_A_USD = "0x7B50775383d3D6f0215A8F290f2C9e2eEBBEceb2"
 BB_A_USD_WHALE = "0xBA12222222228d8Ba445958a75a0704d566BF2C8"
 
+
 def test_after_wait_withdrawSome_unlocks_for_caller(setup_strat, want, vault, deployer):
     ## Try to withdraw all, fail because locked
     initial_dep = vault.balanceOf(deployer)
@@ -41,7 +42,6 @@ def test_after_wait_withdrawSome_unlocks_for_caller(setup_strat, want, vault, de
 
 
 def test_if_change_min_some_can_be_withdraw_easy(setup_strat, vault, deployer, want):
-
     initial_b = want.balanceOf(deployer)
     ## TODO / CHECK This is the ideal math but it seems to revert on me
     ## min = (vault.MAX_BPS() - vault.toEarnBps() - 1) * vault.balanceOf(deployer) / 10000
@@ -85,10 +85,7 @@ def test_after_deposit_locker_has_more_funds(
     ## TEST: Did the proxy get more want?
     locked, _ = locker.balances(strategy)
     # TODO: Shouldn't this be just locker.balanceOf(strategy)?
-    assert (
-        locked + locker.balanceOf(strategy)
-        > intitial_in_locker
-    )
+    assert locked + locker.balanceOf(strategy) > intitial_in_locker
 
 
 def test_locked_balance_after_expiration(
@@ -156,7 +153,9 @@ def test_locked_balance_after_expiration(
     assert strategy.balanceOfWant() == available
 
 
-def test_delegation_was_correct(deployer, vault, strategy, want, governance, randomUser, locker):
+def test_delegation_was_correct(
+    deployer, vault, strategy, want, governance, randomUser, locker
+):
     # Setup
     startingBalance = want.balanceOf(deployer)
     depositAmount = startingBalance // 2
@@ -208,7 +207,9 @@ def test_sweep_rewards(strategy, strategist, bribes_processor):
     assert bbausd.balanceOf(bribes_processor) == balance_processor_before + amount
 
 
-def test_sweep_rewards_with_redirection(strategy, strategist, governance, bribes_processor):
+def test_sweep_rewards_with_redirection(
+    strategy, strategist, governance, bribes_processor
+):
     # Transfer exra reward tokens to the strategy
     amount = 1000e18
     bbausd = interface.IERC20Detailed(BB_A_USD)
@@ -235,10 +236,15 @@ def test_can_set_slippage(strategy, strategist):
     strategy.setAuraBalToBalEthBptMinOutBps(10, {"from": strategist})
     assert strategy.auraBalToBalEthBptMinOutBps() == 10
 
+
 def test_snapshot_delegation(delegation_registry, strategy, governance, strategist):
     target_delegate = "0x14F83fF95D4Ec5E8812DDf42DA1232b0ba1015e6"
-    CONVEX_SPACE_ID = "0x6376782e65746800000000000000000000000000000000000000000000000000"
-    BALANCER_SPACE_ID = "0x62616c616e6365722e6574680000000000000000000000000000000000000000"
+    CONVEX_SPACE_ID = (
+        "0x6376782e65746800000000000000000000000000000000000000000000000000"
+    )
+    BALANCER_SPACE_ID = (
+        "0x62616c616e6365722e6574680000000000000000000000000000000000000000"
+    )
 
     # No delegates set at the beginning
     assert strategy.getSnapshotDelegate(CONVEX_SPACE_ID) == AddressZero
@@ -246,50 +252,60 @@ def test_snapshot_delegation(delegation_registry, strategy, governance, strategi
 
     # Confirm non-governance address cannot set delegate
     with brownie.reverts():
-        strategy.setSnapshotDelegate(CONVEX_SPACE_ID, target_delegate, {'from': strategist})
+        strategy.setSnapshotDelegate(
+            CONVEX_SPACE_ID, target_delegate, {"from": strategist}
+        )
 
     with brownie.reverts():
-        strategy.setSnapshotDelegate(BALANCER_SPACE_ID, target_delegate, {'from': strategist})
+        strategy.setSnapshotDelegate(
+            BALANCER_SPACE_ID, target_delegate, {"from": strategist}
+        )
 
     # Set both spaces to target delegate
-    strategy.setSnapshotDelegate(CONVEX_SPACE_ID, target_delegate, {'from': governance})
-    strategy.setSnapshotDelegate(BALANCER_SPACE_ID, target_delegate, {'from': governance})
+    strategy.setSnapshotDelegate(CONVEX_SPACE_ID, target_delegate, {"from": governance})
+    strategy.setSnapshotDelegate(
+        BALANCER_SPACE_ID, target_delegate, {"from": governance}
+    )
 
     # Confirm via strategy getSnapshotDelegate
     convex_space_delegate = strategy.getSnapshotDelegate(CONVEX_SPACE_ID)
     balancer_space_delegate = strategy.getSnapshotDelegate(BALANCER_SPACE_ID)
-    
+
     assert convex_space_delegate == target_delegate
     assert balancer_space_delegate == target_delegate
-    
+
     # Confirm via snapshot registry directly
     convex_space_delegate = delegation_registry.delegation(strategy, CONVEX_SPACE_ID)
-    balancer_space_delegate = delegation_registry.delegation(strategy, BALANCER_SPACE_ID)
-    
+    balancer_space_delegate = delegation_registry.delegation(
+        strategy, BALANCER_SPACE_ID
+    )
+
     assert convex_space_delegate == target_delegate
     assert balancer_space_delegate == target_delegate
 
     # Confirm non-governance address cannot clear delegate
     with brownie.reverts():
-        strategy.clearSnapshotDelegate(CONVEX_SPACE_ID, {'from': strategist})
+        strategy.clearSnapshotDelegate(CONVEX_SPACE_ID, {"from": strategist})
 
     with brownie.reverts():
-        strategy.clearSnapshotDelegate(BALANCER_SPACE_ID, {'from': strategist})
+        strategy.clearSnapshotDelegate(BALANCER_SPACE_ID, {"from": strategist})
 
     # Clear delegation for both space IDs
-    strategy.clearSnapshotDelegate(CONVEX_SPACE_ID, {'from': governance})
-    strategy.clearSnapshotDelegate(BALANCER_SPACE_ID, {'from': governance})
+    strategy.clearSnapshotDelegate(CONVEX_SPACE_ID, {"from": governance})
+    strategy.clearSnapshotDelegate(BALANCER_SPACE_ID, {"from": governance})
 
     # Confirm via strategy getSnapshotDelegate
     convex_space_delegate = strategy.getSnapshotDelegate(CONVEX_SPACE_ID)
     balancer_space_delegate = strategy.getSnapshotDelegate(BALANCER_SPACE_ID)
-    
+
     assert convex_space_delegate == AddressZero
     assert balancer_space_delegate == AddressZero
-    
+
     # Confirm via snapshot registry directly
     convex_space_delegate = delegation_registry.delegation(strategy, CONVEX_SPACE_ID)
-    balancer_space_delegate = delegation_registry.delegation(strategy, BALANCER_SPACE_ID)
-    
+    balancer_space_delegate = delegation_registry.delegation(
+        strategy, BALANCER_SPACE_ID
+    )
+
     assert convex_space_delegate == AddressZero
     assert balancer_space_delegate == AddressZero

--- a/tests/upgrade/data/hh_claim_data_7_23.json
+++ b/tests/upgrade/data/hh_claim_data_7_23.json
@@ -1,0 +1,31 @@
+{
+    "error": false,
+    "data": [
+        {
+            "symbol": "usdc",
+            "name": "USD Coin",
+            "token": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            "decimals": 6,
+            "chainId": 1,
+            "protocol": "aura",
+            "claimable": "4607.936029",
+            "cumulativeAmount": "4607936029",
+            "value": 4606.5582561273295,
+            "activeTimer": 0,
+            "pausedTimer": 0,
+            "claimMetadata": {
+                "identifier": "0x6b775bb35addec5f55aeb4dae56161752c36517721776c3e623c22ac334c7436",
+                "account": "0x3c0989ef27e3e3fab87a2d7c38b35880c90e63b5",
+                "amount": "4607936029",
+                "merkleProof": [
+                    "0xf839d9112285e2728661d01ad0c14986f6060cb45e7ea4620d9cdd1fa336d596",
+                    "0x877a50ccbff50edad74cef00b8f19881058d6ef524e05f947e7dfd0c792d8723",
+                    "0x81418acd2729ead38463180718899a61334dd6b5a938b9e10882d2ffce44e6c0",
+                    "0xa67d8195e155043a265e3d7adb0952757252a71d9a957f2991029fe06f821fff",
+                    "0x9d4f6c68c356a35532bd20909be9babb43e95144278f51ce846edacef334baf2",
+                    "0x62438928b8f77cfd4aca54fbef7396e4f7c2c6db0ccfd719a2875b6ddc430be6"
+                ]
+            }
+        }
+    ]
+}

--- a/tests/upgrade/test_upgrade.py
+++ b/tests/upgrade/test_upgrade.py
@@ -1,19 +1,24 @@
-import brownie
 import pytest
+import json
 
-from brownie import * 
-
+from brownie import TheVault, MyStrategy, accounts, Contract, web3, interface
 
 SETT_ADDRESS = "0xBA485b556399123261a5F9c95d413B4f93107407"
 STRAT_ADDRESS = "0x3c0989eF27e3e3fAb87a2d7C38B35880C90E63b5"
+
+NEW_REWARDS_DISTRIBUTOR = "0xa9b08B4CeEC1EF29EdEC7F9C94583270337D6416"
+USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+
 
 @pytest.fixture
 def vault_proxy():
     return TheVault.at(SETT_ADDRESS)
 
+
 @pytest.fixture
 def strat_proxy():
     return MyStrategy.at(STRAT_ADDRESS)
+
 
 @pytest.fixture
 def proxy_admin():
@@ -21,14 +26,30 @@ def proxy_admin():
     admin = web3.eth.getStorageAt(STRAT_ADDRESS, ADMIN_SLOT).hex()
     return Contract.from_explorer(admin)
 
+
 @pytest.fixture
 def proxy_admin_gov(proxy_admin):
     """
-        Also found at proxy_admin.owner()
+    Also found at proxy_admin.owner()
     """
     return accounts.at(proxy_admin.owner(), force=True)
 
-def test_check_storage_integrity(strat_proxy, vault_proxy, deployer, proxy_admin, proxy_admin_gov):
+
+@pytest.fixture
+def strategist(strat_proxy):
+    return accounts.at(strat_proxy.strategist(), force=True)
+
+
+@pytest.fixture
+def usdc():
+    usdc = interface.IERC20Detailed(USDC)
+    return usdc
+
+
+@pytest.mark.skip(reason="May depend on mainnet conditions, run when evaluating upgrades")
+def test_check_storage_integrity(
+    strat_proxy, vault_proxy, deployer, proxy_admin, proxy_admin_gov, usdc, strategist
+):
     old_want = strat_proxy.want()
     old_vault = strat_proxy.vault()
     old_withdrawalMaxDeviationThreshold = strat_proxy.withdrawalMaxDeviationThreshold()
@@ -46,15 +67,52 @@ def test_check_storage_integrity(strat_proxy, vault_proxy, deployer, proxy_admin
     ## Check Integrity
     assert old_want == strat_proxy.want()
     assert old_vault == strat_proxy.vault()
-    assert old_withdrawalMaxDeviationThreshold == strat_proxy.withdrawalMaxDeviationThreshold()
+    assert (
+        old_withdrawalMaxDeviationThreshold
+        == strat_proxy.withdrawalMaxDeviationThreshold()
+    )
     assert old_autoCompoundRatio == strat_proxy.autoCompoundRatio()
     assert old_withdrawalSafetyCheck == strat_proxy.withdrawalSafetyCheck()
     assert old_processLocksOnReinvest == strat_proxy.processLocksOnReinvest()
     assert old_bribesProcessor == strat_proxy.bribesProcessor()
     assert old_auraBalToBalEthBptMinOutBps == strat_proxy.auraBalToBalEthBptMinOutBps()
 
-    gov = accounts.at(vault_proxy.governance(), force=True)
+    ## === Test claiming the current round of bribes === ##
+    intial_balance = usdc.balanceOf(strat_proxy.bribesProcessor())
 
-    ## Let's do a quick earn and harvest as well
-    vault_proxy.earn({"from": gov})
-    strat_proxy.harvest({"from": gov})
+    with open("tests/upgrade/data/hh_claim_data_7_23.json", "r") as read_file:
+        data = json.load(read_file)["data"]
+
+    ## Block taken from badger-multisig script
+    ## Reference: https://github.com/Badger-Finance/badger-multisig/blob/0a98cb268661b63221195eb4683cfadfa05e0120/great_ape_safe/ape_api/badger.py#L164
+    def transform_claimable(amount_string, n_decimals):
+        # if the last number is a zero it gets omitted by the api,
+        # here we pad the matissa with zeroes to correct for this
+        assert "." in amount_string
+        splitted = amount_string.split(".")
+        return splitted[0] + splitted[-1].ljust(n_decimals, "0")
+
+    aggregate = {"tokens": [], "amounts": []}
+    for item in data:
+        aggregate["tokens"].append(item["token"])
+        aggregate["amounts"].append(
+            transform_claimable(item["claimable"], item["decimals"])
+        )
+
+    metadata = [
+        (
+            item["claimMetadata"]["identifier"],
+            item["claimMetadata"]["account"],
+            item["claimMetadata"]["amount"],
+            item["claimMetadata"]["merkleProof"],
+        )
+        for item in data
+    ]
+
+    strat_proxy.claimBribesFromHiddenHand(
+        NEW_REWARDS_DISTRIBUTOR, metadata, {"from": strategist}
+    )
+    # Confirm that claimable amount was claimed and transferred to the Bribes Processor
+    amount = aggregate["amounts"][aggregate["tokens"].index(USDC)]
+    assert usdc.balanceOf(strat_proxy.bribesProcessor()) - intial_balance == amount
+    print(f"USDC Claimed: {amount}")


### PR DESCRIPTION
Relates to https://github.com/Badger-Finance/badger-multisig/issues/1335

## Context
Hidden Hands recently introduced new versions of their contracts that [broke](https://github.com/Badger-Finance/badger-multisig/issues/1335#issuecomment-1629713843) graviAURA's claiming flow. The following changes were made to handle the broken changes:
- HH doesn't handle native tokens anymore (any ETH bribes will be handled as wETH from the get go and tagged as such). The reference of the "BRIBES_VAULT" was removed from the claim function along with the separation of ETH special case - no longer applicable.
- Claiming tests checking this special case handling were generalized.
- The upgrade test was adapted to perform a claim of the latest rewards on fork (real claiming data from last round was included) - **Test is set to skip: The skipping [line](https://github.com/Badger-Finance/vested-aura/blob/994f8439ca2c38b789662761cd8eba6d19c00182/tests/upgrade/test_upgrade.py#L49) must be manually commented out to run!**  
- Linting fixes were applied to the affected python files and all of the Solidity files.

## Test results
All tests are passing:
![image](https://github.com/Badger-Finance/vested-aura/assets/25463788/bb0af1b4-3b02-45b6-ae4e-362ec2845255)
